### PR TITLE
Update CalendarUtils.php

### DIFF
--- a/helpers/CalendarUtils.php
+++ b/helpers/CalendarUtils.php
@@ -409,6 +409,7 @@ class CalendarUtils
     }
 
     public static function generateUUid($type = 'event') {
+        Module::registerAutoloader();
         return 'humhub-'.$type.'-' . UUIDUtil::getUUID();
     }
 


### PR DESCRIPTION
We need to check if `UUIDUtil` is registered as in some cases such as https://github.com/humhub/calendar/blob/f1ce6a4c0249eb111719f303e2648708f958c66f/Events.php#L257 it is not already loaded, for example when `humhub\modules\calendar\Events::onRecordBeforeUpdate()` event is triggered.