### PR TITLE
Double length of Location field

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.2.1 (Unreleased)
+--------------------------
+- Fix #283: Double lenght of Location field
+
+
 1.2.0 (April 15, 2022)
 ----------------------
 - Enh #263: Added new participation option "Only by Invite"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 1.2.1 (Unreleased)
 --------------------------
-- Fix #283: Double lenght of Location field
+- Fix #283: Increase Location field max. length to 128 characters
 
 
 1.2.0 (April 15, 2022)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,6 @@ Unreleased
 - Fix #283: Increase Location field max. length to 128 characters
 - Enh #269: Add Close Button to Calendar Entry Modal
 
-
 1.2.0 (April 15, 2022)
 ----------------------
 - Enh #263: Added new participation option "Only by Invite"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog
 =========
 
 Unreleased
---------------------------
+----------------------
 - Fix #283: Increase Location field max. length to 128 characters
 - Enh #269: Add Close Button to Calendar Entry Modal
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.2.1 (Unreleased)
+Unreleased
 --------------------------
 - Fix #283: Increase Location field max. length to 128 characters
 - Enh #269: Add Close Button to Calendar Entry Modal

--- a/migrations/m220422_104254_double_location_length.php
+++ b/migrations/m220422_104254_double_location_length.php
@@ -12,7 +12,6 @@ class m220422_104254_double_location_length extends Migration
      */
     public function safeUp()
     {
-;        $this->addColumn('calendar_entry', 'location', 'varchar(64) DEFAULT NULL');
         $this->alterColumn('calendar_entry', 'location', 'varchar(128) DEFAULT NULL');
     }
 

--- a/migrations/m220422_104254_double_location_length.php
+++ b/migrations/m220422_104254_double_location_length.php
@@ -1,0 +1,40 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220422_104254_double_location_length
+ */
+class m220422_104254_double_location_length extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+;        $this->addColumn('calendar_entry', 'location', 'varchar(64) DEFAULT NULL');
+        $this->alterColumn('calendar_entry', 'location', 'varchar(128) DEFAULT NULL');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        echo "m220422_104254_double_location_length cannot be reverted.\n";
+
+        return false;
+    }
+
+    /*
+    // Use up()/down() to run migration code without a transaction.
+    public function up()
+    {
+    }
+    public function down()
+    {
+        echo "m220422_104254_double_location_length cannot be reverted.\n";
+        return false;
+    }
+    */
+}

--- a/models/CalendarEntry.php
+++ b/models/CalendarEntry.php
@@ -240,7 +240,7 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, Recurrent
             [['end_datetime'], 'validateEndTime'],
             [['recurrence_id'], 'validateRecurrenceId'],
             [['description', 'participant_info'], 'safe'],
-            ['location', 'string', 'max' => 64],
+            ['location', 'string', 'max' => 128],
         ];
     }
 


### PR DESCRIPTION
The 64 character limit does not allow to paste Zoom links that include a longer meeting password.
In my specific use-case the link was 73 characters long.

I have chosen 128 rather randomly, followed by the "in doubt double capacity" principle.