### PR TITLE
Double length for location field in edit dialog

### DIFF
--- a/views/entry/edit-basic.php
+++ b/views/entry/edit-basic.php
@@ -33,7 +33,7 @@ use yii\jui\DatePicker;
                                     {input}
                                 </div>
                                 {error}{hint}'
-        ])->textInput(['placeholder' => Yii::t('CalendarModule.views_entry_edit', 'Title'), 'maxlength' => 200])->label(false) ?>
+        ])->textInput(['placeholder' => Yii::t('CalendarModule.views_entry_edit', 'Title')])->label(false) ?>
     </div>
 
     <?php Yii::$app->formatter->timeZone = $calendarEntryForm->timeZone ?>
@@ -58,7 +58,7 @@ use yii\jui\DatePicker;
 
     <div class="row">
         <div class="col-md-6">
-            <?= $form->field($calendarEntryForm->entry, 'location')->textInput(['maxlength' => 128]) ?>
+            <?= $form->field($calendarEntryForm->entry, 'location')->textInput() ?>
         </div>
         <div class="col-md-6 timeZoneField"<?= $calendarEntryForm->entry->all_day ? ' hidden' : '' ?>>
             <?= TimeZoneDropdownAddition::widget(['model' => $calendarEntryForm])?>

--- a/views/entry/edit-basic.php
+++ b/views/entry/edit-basic.php
@@ -58,7 +58,7 @@ use yii\jui\DatePicker;
 
     <div class="row">
         <div class="col-md-6">
-            <?= $form->field($calendarEntryForm->entry, 'location')->textInput(['maxlength' => 64]) ?>
+            <?= $form->field($calendarEntryForm->entry, 'location')->textInput(['maxlength' => 128]) ?>
         </div>
         <div class="col-md-6 timeZoneField"<?= $calendarEntryForm->entry->all_day ? ' hidden' : '' ?>>
             <?= TimeZoneDropdownAddition::widget(['model' => $calendarEntryForm])?>


### PR DESCRIPTION
I stumbled over the hard-coded value after deploying version 1.2.1 and realizing #283 is not yet fixed.

I overlooked this because GitHub does not return a match for this file when searching for `64`.


@luke- 
I am wondering if a better approach would be to grab the length for the location field (and possible the `Title` field) from the data model instead of hard-coding here?