### PR TITLE
Fix null in DateTime on PHP 8.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 1.2.6 (Unreleased)
 --------------------
 - Fix #327: Don't send notifications for canceled event
+- Fix #334: Fix null in DateTime on PHP 8.1
 
 
 1.2.5 (July 15, 2022)

--- a/helpers/CalendarUtils.php
+++ b/helpers/CalendarUtils.php
@@ -75,7 +75,7 @@ class CalendarUtils
             $ts += static::parseTime($timeValue, $timeFormat);
         }
 
-        $date = new DateTime(null, new DateTimeZone('UTC'));
+        $date = new DateTime('now', new DateTimeZone('UTC'));
         $date->setTimestamp($ts);
 
         $result = DateTime::createFromFormat(static::DB_DATE_FORMAT, static::toDBDateFormat($date), static::getDateTimeZone($timeZone));

--- a/models/CalendarEntry.php
+++ b/models/CalendarEntry.php
@@ -311,7 +311,7 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, Recurrent
      */
     public function validateEndTime($attribute, $params)
     {
-        if (new DateTime($this->start_datetime) >= new DateTime($this->end_datetime)) {
+        if (new DateTime($this->start_datetime ?? 'now') >= new DateTime($this->end_datetime ?? 'now')) {
             $this->addError($attribute, Yii::t('CalendarModule.base', "End time must be after start time!"));
         }
     }
@@ -348,8 +348,8 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, Recurrent
 
     public function beforeSave($insert)
     {
-        $start = new DateTime($this->start_datetime);
-        $end = new DateTime($this->end_datetime);
+        $start = new DateTime($this->start_datetime ?? 'now');
+        $end = new DateTime($this->end_datetime ?? 'now');
 
         // Make sure end and start time is set right for all_day events
         if ($this->all_day) {
@@ -505,7 +505,7 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, Recurrent
      */
     public function getStartDateTime()
     {
-        return new DateTime($this->start_datetime, CalendarUtils::getSystemTimeZone());
+        return new DateTime($this->start_datetime ?? 'now', CalendarUtils::getSystemTimeZone());
     }
 
     /**
@@ -514,7 +514,7 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, Recurrent
      */
     public function getEndDateTime()
     {
-        return new DateTime($this->end_datetime, CalendarUtils::getSystemTimeZone());
+        return new DateTime($this->end_datetime ?? 'now', CalendarUtils::getSystemTimeZone());
     }
 
     /**
@@ -1004,6 +1004,6 @@ class CalendarEntry extends ContentActiveRecord implements Searchable, Recurrent
     public function isPast(): bool
     {
         $timeZone = CalendarUtils::getEndTimeZone($this);
-        return new DateTime('now', $timeZone) > new DateTime($this->end_datetime, $timeZone);
+        return new DateTime('now', $timeZone) > new DateTime($this->end_datetime ?? 'now', $timeZone);
     }
 }


### PR DESCRIPTION
Fix `null` value in first param of `new DateTime()` on PHP 8.1