### PR TITLE
Attach ICS files to "forced invites"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ------------------------
 Fix #437: Hide the profile calendar if the module is not available for users
+Fix #439: Attach ICS files to "forced invites"
 
 1.5.7 (January 12, 2024)
 ------------------------

--- a/notifications/ForceAdd.php
+++ b/notifications/ForceAdd.php
@@ -12,6 +12,7 @@ use humhub\libs\Html;
 use humhub\modules\calendar\models\CalendarEntry;
 use humhub\modules\notification\components\BaseNotification;
 use Yii;
+use yii\mail\MessageInterface;
 
 /**
  * @var $source CalendarEntry
@@ -64,5 +65,22 @@ class ForceAdd extends BaseNotification
             'displayName' =>  Html::encode($this->originator->displayName),
             'contentTitle' => $this->getContentInfo($this->source, false)
         ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function beforeMailSend(MessageInterface $message)
+    {
+        $ics = $this->source->generateIcs();
+
+        if (!empty($ics)) {
+            $message->attachContent($ics, [
+                'fileName' => $this->source->getUid() . '.ics',
+                'contentType' => 'text/calendar'
+            ]);
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
#436 added ICS attachments to Invite notification emails.

The code path only triggers when individual members are being invited to an event, but not if `Add all Space members with status` was set to `Invited`.

This PR is the equivalent of #436 for these types of invitation notifications.