### PR TITLE
Send event update notifcation to invitees

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ------------------------
 Fix #437: Hide the profile calendar if the module is not available for users
+Fix #441: Send event update notifcation to invitees
 
 1.5.7 (January 12, 2024)
 ------------------------

--- a/models/participation/CalendarEntryParticipation.php
+++ b/models/participation/CalendarEntryParticipation.php
@@ -162,6 +162,7 @@ class CalendarEntryParticipation extends Model implements CalendarEventParticipa
     public function sendUpdateNotification($notificationClass = EventUpdated::class)
     {
         $participants = $this->findParticipants([
+            CalendarEntryParticipant::PARTICIPATION_STATE_INVITED,
             CalendarEntryParticipant::PARTICIPATION_STATE_MAYBE,
             CalendarEntryParticipant::PARTICIPATION_STATE_ACCEPTED])->all();
 


### PR DESCRIPTION
The previous behaviour only send notifications about event updates/ changes to accounts that had responded with `Maybe` or `Accepted` to an event.

This change also sends notifications to accounts still in `Invited` status, aka accounts who have not responded to the invite.


I successfully tested that accounts who have declined participation will not receive an update notification.


Background:
When an event gets changed (e.g new date & time) invitees how have not replied to the event will not get notified about the change in date & time.

With the changes around adding ICS files to calendar notifications (#435 and #439) this can lead to external calendars not receiving updated ICS files with the new date & time. Hence those calendars start being out of sync.
