### PR TITLE
Fix tests for core v1.16+

### DIFF
--- a/integration/BirthdayCalendarQuery.php
+++ b/integration/BirthdayCalendarQuery.php
@@ -79,7 +79,7 @@ class BirthdayCalendarQuery extends AbstractCalendarQuery
             return;
         }
 
-        if (!Yii::$app->user->isGuest && Yii::$app->getModule('friendship')->isEnabled) {
+        if (!Yii::$app->user->isGuest && Yii::$app->getModule('friendship')->settings->get('enable')) {
             $this->_query->innerJoin('user_friendship', 'user.id=user_friendship.friend_user_id AND user_friendship.user_id=:userId',
                 [':userId' => Yii::$app->user->id]);
         } else {
@@ -115,7 +115,7 @@ class BirthdayCalendarQuery extends AbstractCalendarQuery
         $friendshipSubQuery = (new Query())->select('user_friendship.friend_user_id')->from('user_friendship')->where(['user_friendship.user_id' => Yii::$app->user->id]);
         $followerSubQuery = (new Query())->select('user_follow.object_id')->from('user_follow')->where(['user_follow.user_id' => Yii::$app->user->id])->andWhere(['object_model' => User::class]);
 
-        if (!Yii::$app->user->isGuest && Yii::$app->getModule('friendship')->isEnabled) {
+        if (!Yii::$app->user->isGuest && Yii::$app->getModule('friendship')->settings->get('enable')) {
             $conditions[] = ['in', 'profile.user_id', $friendshipSubQuery];
             $conditions[] = ['in', 'profile.user_id', $followerSubQuery];
         } else {


### PR DESCRIPTION
Issue: https://github.com/humhub/calendar/actions/runs/7583134176/job/20654131536#step:25:253

Here https://github.com/humhub/humhub/pull/6745/files#diff-ba7b8761764d032b4ad21f00cd5a99380bfd7da056e9c5c90702738a6983f5d9R29 the method `friendship\Module::getIsEnabled()` was replaced with new `friendship\Module::isFriendshipEnabled()`.

I have decided to use `->settings->get('enable')` instead of new `->isFriendshipEnabled()` because of error on versions older 16.

Same issues should be fixed in the modules `cfiles` and `tasks`.