### PR TITLE
Enable "Upcoming events" widget if no calendar entry exists

### DIFF
--- a/widgets/UpcomingEvents.php
+++ b/widgets/UpcomingEvents.php
@@ -47,10 +47,6 @@ class UpcomingEvents extends Widget
 
         $calendarEntries = $calendarService->getUpcomingEntries($this->contentContainer, $settings->upcomingEventsSnippetDuration, $settings->upcomingEventsSnippetMaxItems, $filters);
 
-        if (empty($calendarEntries)) {
-            return;
-        }
-
         return $this->render('upcomingEvents', ['calendarEntries' => $calendarEntries, 'calendarUrl' => Url::toCalendar($this->contentContainer)]);
     }
 

--- a/widgets/views/upcomingEvents.php
+++ b/widgets/views/upcomingEvents.php
@@ -23,25 +23,35 @@ $extraMenus = Html::tag('li', $link);
     <div class="panel-body" style="padding:0;">
         <hr style="margin:0">
         <ul class="media-list">
-            <?php foreach ($calendarEntries as $entry) : ?>
-                <?php $formatter = new CalendarDateFormatter(['calendarItem' => $entry]); ?>
-                <?php $color = ($entry->color) ? $entry->color : $this->theme->variable('info') ?>
-                <a href="<?= $entry->getUrl() ?>">
-                    <li style="border-left: 3px solid <?= Html::encode($color) ?>">
-                        <div class="media">
-                            <div class="media-body  text-break">
-                                <?=  $entry->getBadge() ?>
-                                <strong>
-                                    <?= Helpers::trimText(Html::encode($entry->getTitle()), 60) ?>
-                                </strong>
-
-                                <br />
-                                <span class="time"><?= $formatter->getFormattedTime('medium') ?></span>
-                            </div>
+            <?php if (empty($calendarEntries)) { ?>
+                <li style="border-left: 3px solid ">
+                    <div class="media">
+                        <div class="media-body  text-break">
+                            <?= Yii::t('CalendarModule.base', 'There are no events yet.') ?>
                         </div>
-                    </li>
-                </a>
-            <?php endforeach; ?>
+                    </div>
+                </li>
+            <?php } else { ?>
+                <?php foreach ($calendarEntries as $entry) : ?>
+                    <?php $formatter = new CalendarDateFormatter(['calendarItem' => $entry]); ?>
+                    <?php $color = ($entry->color) ? $entry->color : $this->theme->variable('info') ?>
+                    <a href="<?= $entry->getUrl() ?>">
+                        <li style="border-left: 3px solid <?= Html::encode($color) ?>">
+                            <div class="media">
+                                <div class="media-body  text-break">
+                                    <?=  $entry->getBadge() ?>
+                                    <strong>
+                                        <?= Helpers::trimText(Html::encode($entry->getTitle()), 60) ?>
+                                    </strong>
+
+                                    <br />
+                                    <span class="time"><?= $formatter->getFormattedTime('medium') ?></span>
+                                </div>
+                            </div>
+                        </li>
+                    </a>
+                <?php endforeach; ?>
+            <?php } ?>
         </ul>
     </div>
 


### PR DESCRIPTION
This PR is a draft for https://github.com/humhub/calendar/issues/455

The goal is to enable the "Upcoming events" widget even if no calendar event exists to be shown.

In case of an empty calendar, the widgets renders "There are no events yet."

![image](https://github.com/humhub/calendar/assets/90508808/b7cee1ed-de3e-4c6b-abed-e4a4432b2139)

The discoloration of the screenshot is related to my hyprland transparency config, not an effect of this PR.