### PR TITLE
Enh canceled vcalendar

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog
 - Fix #447: Global calendar header redesign
 - Enh #440: Extend list of fields for updating of sequence
 - Fix #453: Profile Calendar not available when adding an event from the global Calendar when the module is enabled in the profile
+- Enh #457: Strikethrough cancelled events in calendar view
+- Enh: Add cancelled status in ICS files
 
 1.5.8 (January 19, 2024)
 ------------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ Changelog
 - Enh #440: Extend list of fields for updating of sequence
 - Fix #453: Profile Calendar not available when adding an event from the global Calendar when the module is enabled in the profile
 - Enh #457: Strikethrough cancelled events in calendar view
-- Enh: Add cancelled status in ICS files
+- Enh #460: Add cancelled status in ICS files
 
 1.5.8 (January 19, 2024)
 ------------------------

--- a/interfaces/VCalendar.php
+++ b/interfaces/VCalendar.php
@@ -147,6 +147,10 @@ class VCalendar extends Model
             'DTEND' => $dtEnd,
             'SUMMARY' => $item->getTitle(),
         ];
+        
+        if (isset($item->closed) && $item->closed) {
+            $result['STATUS'] = 'CANCELLED';
+        }
 
         if (!empty($item->getLocation())) {
             $result['LOCATION'] = $item->getLocation();


### PR DESCRIPTION
closes https://github.com/humhub/calendar/issues/459

This simply adds 'STATUS:CANCELLED' to the ICS file for a cancelled event. 
(It also affects calendar exports via the external_calendar module).

Tested with https://icalendar.org/validator.html - no errors found.

Note: I have also added the changelog for #457 because I missed that there.