### PR TITLE
Improved URLs

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -14,7 +14,11 @@ use humhub\modules\content\components\ContentContainerActiveRecord;
 
 class Module extends ContentContainerModule
 {
+    /**
+     * @var string the default route of this module.
+     */    
     public $defaultRoute = 'view';
+    
     /**
      * @var bool feature switch for recurrence events
      */

--- a/Module.php
+++ b/Module.php
@@ -14,6 +14,7 @@ use humhub\modules\content\components\ContentContainerActiveRecord;
 
 class Module extends ContentContainerModule
 {
+    public $defaultRoute = 'view';
     /**
      * @var bool feature switch for recurrence events
      */

--- a/config.php
+++ b/config.php
@@ -39,4 +39,7 @@ return [
         ['class' => User::class, 'event' => User::EVENT_BEFORE_DELETE, 'callback' => [Events::class, 'onUserDelete']],
         ['class' => 'humhub\modules\rest\Module', 'event' => 'restApiAddRules', 'callback' => [Events::class, 'onRestApiAddRules']],
     ],
+    'urlManagerRules' => [
+        'calendar' => 'calendar/global'
+    ]
 ];

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 -----------------------
 - Fix #509: Fix event type visibility
 - Enh #512: Surround the widget wall entry links with a dedicated HTML class
+- Enh #516: Improved calendar page URLs
 
 1.6.4 (Unreleased)
 -----------------------

--- a/helpers/Url.php
+++ b/helpers/Url.php
@@ -90,7 +90,7 @@ class Url extends BaseUrl
     public static function toCalendar(ContentContainerActiveRecord $container = null)
     {
         if ($container) {
-            return $container->createUrl('/calendar/view/index');
+            return $container->createUrl('/calendar');
         }
 
         return static::toGlobalCalendar();
@@ -98,7 +98,7 @@ class Url extends BaseUrl
 
     public static function toGlobalCalendar()
     {
-        return static::to(['/calendar/global/index']);
+        return static::to(['/calendar']);
     }
 
     public static function toEditItemType(CalendarTypeIF $type, ContentContainerActiveRecord $container = null)


### PR DESCRIPTION
- `/calendar` as URL for the global calendar
- `/s/space/calendar` for the space calendar
- `/u/user/calendar` for the profile calendar

Those URLs are more user friendly (easy to remember and share) and SEO friendly.

The old URLs (`/calendar/global/index` and `/s/space/calendar/view`) still work.

**To do:**
- [x] changelog