### PR TITLE
fix wrong URL (use absolute url instead of relative)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+TBA
+------------------------
+- Fix #521: Fix global calendar url
+
 1.7.0 (January 14, 2025)
 ------------------------
 - Fix #509: Fix event type visibility

--- a/helpers/Url.php
+++ b/helpers/Url.php
@@ -98,7 +98,7 @@ class Url extends BaseUrl
 
     public static function toGlobalCalendar()
     {
-        return static::to(['calendar/global']);
+        return static::to(['/calendar/global']);
     }
 
     public static function toEditItemType(CalendarTypeIF $type, ContentContainerActiveRecord $container = null)


### PR DESCRIPTION
This should fix https://github.com/humhub/humhub/issues/7393

I can reproduce the error: When the start page is a custom page the generated global calendar URL in the top navigation is `https://DOMAIN/custom_pages/calendar/global` which is obviously wrong.

(The mistake happened in https://github.com/humhub/calendar/pull/520)