### PR TITLE
Enh: Show the "Filter by types" filter only if a list a type is available

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 1.7.2 (Unreleased)
 ------------------------
 - Fix #525: Fix Space calendar header
+- Enh: Show the "Filter by types" filter only if a list a type is available
 
 1.7.1 (January 17, 2025)
 ------------------------

--- a/widgets/CalendarFilterBar.php
+++ b/widgets/CalendarFilterBar.php
@@ -10,6 +10,9 @@
 namespace humhub\modules\calendar\widgets;
 
 use humhub\components\Widget;
+use humhub\modules\calendar\models\CalendarEntryType;
+use humhub\modules\content\helpers\ContentContainerHelper;
+use humhub\modules\content\models\ContentTag;
 use Yii;
 
 /**
@@ -33,6 +36,13 @@ class CalendarFilterBar extends Widget
         if (Yii::$app->user->isGuest) {
             return '';
         }
+
+        $currentContentContainer = ContentContainerHelper::getCurrent();
+        $typesQuery = ContentTag::find()->where(['type' => CalendarEntryType::class]);
+        if ($currentContentContainer) {
+            $typesQuery->andWhere(['contentcontainer_id' => $currentContentContainer->contentcontainer_id]);
+        }
+        $this->showTypes = $this->showTypes && $typesQuery->exists();
 
         return $this->render('calendarFilterBar', [
             'filters' => $this->filters,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/eb003332-1c05-4c53-a645-1453026d70e8)

This PR show the "Filter by types" filter only if a list a type is available, either globally and for a space (if displayed in the global calendar), or for the current space.