### PR TITLE
Exempt CalDAV from the core user gates by disabling the session

### DIFF
--- a/controllers/CalDavController.php
+++ b/controllers/CalDavController.php
@@ -16,7 +16,6 @@ use humhub\modules\user\models\UserFilter;
 use Sabre\CalDAV\CalendarRoot;
 use Sabre\DAVACL\PrincipalCollection;
 use Yii;
-use yii\base\Event;
 use yii\helpers\Url;
 use Sabre\DAV\Server;
 use Sabre\DAV\Sharing\Plugin as DAVPlugin;
@@ -83,15 +82,17 @@ class CalDavController extends Controller
 
     public function beforeAction($action)
     {
+        // CalDAV authenticates statelessly per request (HTTP Basic / token). Disabling the
+        // session marks the request as an API request, so the core user gates (2FA, terms,
+        // ...) do not intercept the sync — they only apply to session-authenticated
+        // requests. Replaces the former `twofa.beforeCheck` opt-out, which was removed
+        // when the twofa module moved to the core user gate system.
+        Yii::$app->user->enableSession = false;
 
         if ($action->id == 'well-known') {
             // Allow `REPORT` and `PROPFIND` request for guests
             return true;
         }
-
-        Yii::$app->on('twofa.beforeCheck', function (Event $event) use ($action): void {
-            $event->handled = true;
-        });
 
         return parent::beforeAction($action);
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.9.2 (Unreleased)
+------------------
+- Fix: CalDAV sync was intercepted by the core user gates (e.g. 2FA) for affected users after the twofa module moved to the gate system — the CalDAV controller now runs without a session, so the gates treat it as a stateless API request and leave the sync untouched (replaces the removed `twofa.beforeCheck` opt-out)
+
 1.9.1 (July 8, 2026)
 --------------------
 - Enh #702: Add aria-label attribute for icon-only buttons

--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
     "keywords": [
         "calendar"
     ],
-    "version": "1.9.1",
+    "version": "1.9.2",
     "humhub": {
         "minVersion": "1.19"
     },

--- a/tests/codeception/functional/CalDavCest.php
+++ b/tests/codeception/functional/CalDavCest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2026 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+namespace calendar\functional;
+
+use calendar\FunctionalTester;
+use Yii;
+
+class CalDavCest
+{
+    /**
+     * CalDAV authenticates statelessly per request, so the controller disables the session.
+     * This marks the request as an API request for the core user gates (2FA, terms, ...),
+     * which only apply to session-authenticated requests — keeping the sync reachable for
+     * users who would otherwise be intercepted (see core docs/develop/user-gates.md).
+     */
+    public function testCalDavRequestDisablesSession(FunctionalTester $I)
+    {
+        $I->wantTo('ensure CalDAV requests run without a session so the user gates do not intercept them');
+
+        $I->stopFollowingRedirects();
+        $I->amOnRoute('/calendar/cal-dav/well-known');
+
+        $I->assertFalse(Yii::$app->user->enableSession, 'CalDAV controller must disable the session');
+    }
+}


### PR DESCRIPTION
CalDAV authenticates statelessly per request (HTTP Basic / token). Since the twofa module moved to the core user gate system (humhub/twofa#118), the former `twofa.beforeCheck` opt-out it relied on no longer exists.

Unlike the REST module, the CalDAV controller kept the session enabled, so the core gate dispatcher classified a CalDAV request as a full-page request (see humhub/humhub#8295). For an affected user — e.g. one with 2FA enforced — a gate would then intercept the request and the CalDAV sync would break.

`CalDavController::beforeAction()` now sets `Yii::$app->user->enableSession = false`, so the request is classified as a stateless API request and the gates leave it untouched — consistent with how the REST module is handled, and semantically correct since CalDAV does not use a session. The dead `twofa.beforeCheck` listener is removed.

Requires core >= 1.19 (already the module's `minVersion`).

Adds `CalDavCest` (functional): a CalDAV request runs with the session disabled.
