### PR TITLE
Prevent silent demotion of a public profile calendar event to private when edited by a user without CreatePublicContent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.8.19 (Unreleased)
+--------------------------
+- Fix #715: Prevent silent demotion of a public profile calendar event to private when edited by a user without CreatePublicContent
+
 1.8.18 (September 8, 2026)
 --------------------------
 - Enh: Automated code refactoring for HumHub 1.18.0-beta.7 using Rector

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 1.8.19 (Unreleased)
 --------------------------
-- Fix #715: Prevent silent demotion of a public profile calendar event to private when edited by a user without CreatePublicContent
+- Fix #715: Prevent public calendar events (profile edits and auto-materialized recurring instances) from being silently saved private for users without CreatePublicContent
 
 1.8.18 (September 8, 2026)
 --------------------------

--- a/models/forms/CalendarEntryForm.php
+++ b/models/forms/CalendarEntryForm.php
@@ -359,9 +359,17 @@ class CalendarEntryForm extends Model
             $this->entry->time_zone = $this->timeZone;
         }
 
-        $container = $this->entry->content->container;
         if (!$this->canCreatePublicEntry()) {
-            $this->entry->content->visibility = Content::VISIBILITY_PRIVATE;
+            // The "Public" field is hidden from editors without CreatePublicContent (e.g. a
+            // system admin editing another user's content for moderation purposes, or a space
+            // role that can manage entries but not create public content). A hidden field must
+            // not silently change on save: only default *new* records to private here - leave
+            // an *existing* record's visibility untouched, otherwise every edit by such an
+            // editor silently flips an already-public event to private for everyone else.
+            // See: HumHub Calendar - "event disappears after unrelated edit" investigation.
+            if ($this->entry->isNewRecord) {
+                $this->entry->content->visibility = Content::VISIBILITY_PRIVATE;
+            }
         } else {
             $this->entry->content->visibility = $this->is_public;
         }

--- a/models/recurrence/CalendarRecurrenceExpand.php
+++ b/models/recurrence/CalendarRecurrenceExpand.php
@@ -328,6 +328,20 @@ class CalendarRecurrenceExpand extends Model
             if (!$model->saveEvent()) {
                 throw new Exception('Could not safe recurrent event');
             }
+
+            // This is an internal system flow: the instance is auto-materialized from its already
+            // public root event (visibility already copied 1:1 above via syncEventData()), in the
+            // context of whichever user happens to be viewing/expanding it - not necessarily the
+            // event's author and not necessarily someone with permission to create public content
+            // themselves. Content::beforeSave() may have silently demoted the freshly inserted
+            // instance back to private for such a viewer, even though the root event is public.
+            // Restore the inherited visibility directly via updateAttributes(), which - unlike
+            // save() - does not run validation or trigger beforeSave()/afterSave(), so this does
+            // not re-run (and get blocked by) the same permission check again.
+            // See: https://github.com/humhub/humhub/issues/8443
+            if ((int) $model->content->visibility !== (int) $root->content->visibility) {
+                $model->content->updateAttributes(['visibility' => $root->content->visibility]);
+            }
         }
 
         return $model;

--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
     "keywords": [
         "calendar"
     ],
-    "version": "1.8.18",
+    "version": "1.8.19",
     "humhub": {
         "minVersion": "1.18.0-beta.7",
         "maxVersion": "1.18"


### PR DESCRIPTION
https://github.com/humhub/humhub/issues/8443#issuecomment-5604690987